### PR TITLE
Remove padding of logo container div

### DIFF
--- a/src/astros/Logo.astro
+++ b/src/astros/Logo.astro
@@ -28,7 +28,7 @@ try {
   logoUrl ? (
     <div
       class={twMerge(
-        "size-10 flex items-center justify-center bg-linear-135 from-primary-bold to-primary-light/50 shadow-lg shadow-primary-light/20 text-white rounded-xl overflow-hidden p-1.5",
+        "size-10 flex items-center justify-center shadow-lg shadow-primary-light/20 text-white rounded-[0.7rem] overflow-hidden",
         className,
       )}
     >

--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -22,7 +22,7 @@ const session = await getSession(Astro.request);
         <AdminLogin client:load>
           <Logo
             slot="logo"
-            className="size-16 rounded-2xl p-2"
+            className="size-16 rounded-2xl"
             iconClassName="text-3xl"
           />
           <SiteTitle slot="title" />


### PR DESCRIPTION
Change according to https://github.com/EMOBase/emobase-web/issues/3

As decided, the logo should contain the yellow background, so we remove bg & padding from the logo container